### PR TITLE
Fixed create wemail_forms table on plugin active

### DIFF
--- a/includes/Install.php
+++ b/includes/Install.php
@@ -24,14 +24,17 @@ class Install {
         $api        = apply_filters( 'wemail_api_url', 'https://api.getwemail.io/v1' );
         $wemail_api = untrailingslashit( $api );
 
-        wp_remote_post( $wemail_api . '/site/update-activation-status', [
-            'headers' => [
-                'x-api-key' => $api_key,
-            ],
-            'body' => [
-                'deactivated' => false,
-            ],
-        ] );
+        wp_remote_post(
+            $wemail_api . '/site/update-activation-status',
+            [
+                'headers' => [
+                    'x-api-key' => $api_key,
+                ],
+                'body' => [
+                    'deactivated' => false,
+                ],
+            ]
+        );
 
         // set the redirection to setup wizard
         set_transient( 'wemail_activation_redirect', true, 30 );
@@ -43,25 +46,9 @@ class Install {
      * @return void
      */
     public static function create_tables() {
-        global $wpdb;
+        $path = trailingslashit( __DIR__ );
+        $file_name = 'Upgrades/upgrade-1.0.0.php';
 
-        $charset_collate = $wpdb->get_charset_collate();
-        $table_schema    = "CREATE TABLE IF NOT EXISTS `{$wpdb->prefix}wemail_forms` (
-            `id` varchar(36) NOT NULL,
-            `name` varchar(150) DEFAULT NULL,
-            `template` longtext NULL,
-            `plugin_version` varchar(10) NULL,
-            `settings` longtext NULL,
-            `type` varchar(191) DEFAULT 'inline',
-            `status` tinyint(1) DEFAULT '1',
-            `deleted_at` timestamp NULL DEFAULT NULL,
-            PRIMARY KEY (`id`)
-        ) {$charset_collate}";
-
-        if ( ! function_exists( 'dbDelta' ) ) {
-            require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-        }
-
-        dbDelta( $table_schema );
+        include $path . $file_name;
     }
 }

--- a/includes/Upgrade.php
+++ b/includes/Upgrade.php
@@ -3,9 +3,21 @@ namespace WeDevs\WeMail;
 
 class Upgrade {
 
+    /**
+     * Lists of upgrades
+     *
+     * @var string[] $upgrades
+     */
     protected $upgrades = [
         '1.0.0' => 'Upgrades/upgrade-1.0.0.php',
     ];
+
+    /**
+     * WeMail version option key
+     *
+     * @var string $option_name
+     */
+    protected $option_name = 'wemail_version';
 
     /**
      * Get the plugin version
@@ -13,7 +25,7 @@ class Upgrade {
      * @return string
      */
     protected function get_version() {
-        return get_option( 'wemail_version', '0.14.0' );
+        return get_option( $this->option_name, '0.14.0' );
     }
 
     /**
@@ -22,13 +34,8 @@ class Upgrade {
      * @return bool
      */
     public function needs_update() {
-
-        //check if current version is greater then installed version and any update key is available
-        if ( version_compare( $this->get_version(), WEMAIL_VERSION, '<' ) && in_array( WEMAIL_VERSION, array_keys( $this->upgrades ) ) ) {
-            return true;
-        }
-
-        return false;
+        // check if current version is greater then installed version
+        return version_compare( $this->get_version(), WEMAIL_VERSION, '<' );
     }
 
     /**
@@ -43,11 +50,11 @@ class Upgrade {
         foreach ( $this->upgrades as $version => $file ) {
             if ( version_compare( $installed_version, $version, '<' ) ) {
                 include $path . $file;
-                update_option( 'wemail_version', $version );
+                update_option( $this->option_name, $version );
             }
         }
 
-        update_option( 'wemail_version', WEMAIL_VERSION );
+        update_option( $this->option_name, WEMAIL_VERSION );
     }
 
 }


### PR DESCRIPTION
- Use `Upgrades/upgrade-1.0.0.php` file which is responsible for create `wemail_forms` table if not exists inside of `Install::install()` function.
-  Remove `in_array( WEMAIL_VERSION, array_keys( $this->upgrades ) ) ` from `needs_update` method