### PR TITLE
Hotfix - weMail Forms button initialization error on classic block - MASTER

### DIFF
--- a/assets/js/wemail-tinymce-shortcode.js
+++ b/assets/js/wemail-tinymce-shortcode.js
@@ -28,7 +28,9 @@
             });
         },
     });
-
-    tinymce.PluginManager.add('wemail_forms_button', tinymce.plugins.wemail_forms_button);
+    
+    if (window.hasOwnProperty('wemail_forms_shortcode_button')) {
+        tinymce.PluginManager.add('wemail_forms_button', tinymce.plugins.wemail_forms_button);
+    }
 
 })(jQuery);


### PR DESCRIPTION
Tested on `stagingwp.getwemail.io`