### PR TITLE
Enhance review notice and fixed other issues

### DIFF
--- a/includes/Core/Form/Integrations/EverestForms.php
+++ b/includes/Core/Form/Integrations/EverestForms.php
@@ -68,7 +68,11 @@ class EverestForms extends AbstractIntegration {
             ];
         }
 
-        return $forms;
+        return array_filter(
+            $forms, function( $form ) {
+				return ! empty( $form['fields'] );
+			}
+        );
     }
 
     /**
@@ -78,8 +82,13 @@ class EverestForms extends AbstractIntegration {
     public function get_fields( $post ) {
         $fields = [];
 
-        $form_fields = json_decode( $post->post_content )->form_fields;
-        $get_columns = get_object_vars( $form_fields );
+        $content = json_decode( $post->post_content );
+
+        if ( ! isset( $content->form_fields ) ) {
+            return $fields;
+        }
+
+        $get_columns = get_object_vars( $content->form_fields );
         foreach ( $get_columns as $get_column ) {
             $fields[] = [
                 'id' => $get_column->id,

--- a/includes/Upgrades/upgrade-1.10.0.php
+++ b/includes/Upgrades/upgrade-1.10.0.php
@@ -5,7 +5,12 @@ function wemail_add_installed_time() {
         \WeDevs\WeMail\WeMail::instance()->set_wemail_api();
         $site = \WeDevs\WeMail\Core\Api\Api::instance()
             ->auth()->sites( get_option( 'wemail_site_slug' ) )->get();
-        update_option( 'wemail_installed_time', strtotime( $site['data']['created_at'] ) );
+
+        if ( ! is_wp_error( $site ) && is_array( $site ) ) {
+            update_option( 'wemail_installed_time', strtotime( $site['data']['created_at'] ) );
+        } else {
+            update_option( 'wemail_installed_time', time() );
+        }
     }
 }
 


### PR DESCRIPTION
- Checking `WP_Error` on the upgrade file
- Notice will show only `wemail` admin page
- Campaign throttle to campaign count checking using transient API
- Campaign count checking is now using `meta.total` instead of `count($data)`
- Get only completed campaigns
- Handle empty form fields