### PR TITLE
🛠️ [FIX] Get order permalink.

### DIFF
--- a/includes/Rest/Resources/Ecommerce/WooCommerce/OrderResource.php
+++ b/includes/Rest/Resources/Ecommerce/WooCommerce/OrderResource.php
@@ -44,11 +44,11 @@ class OrderResource extends JsonResource {
         if ( $this->is_refund( $data['type'] ) ) {
             /** @var $order \Automattic\WooCommerce\Admin\Overrides\OrderRefund */
             $data['customer_id']  = $this->get_customer_id( wc_get_order( $order->get_parent_id() )->get_billing_email() );
-            $data['permalink']    = get_edit_post_link( $order->get_parent_id(), 'raw' );
+            $data['permalink']    = wc_get_order( $order->get_parent_id() )->get_edit_order_url();
             $data['completed_at'] = $order->get_date_modified()->setTimezone( new DateTimeZone( 'UTC' ) )->format( self::DATE_FORMAT );
         } else {
             $data['customer']     = $this->customer( $order );
-            $data['permalink']    = get_edit_post_link( $order->get_id(), 'raw' );
+            $data['permalink']    = $order->get_edit_order_url();
             $data['customer_id']  = $this->get_customer_id( $data['customer']['email'] );
             $completed_date       = $order->get_date_completed();
             $data['completed_at'] = $completed_date && $this->is_completed( $this->get_status( $order->get_status() ) ) ? $completed_date->setTimezone( new DateTimeZone( 'UTC' ) )->format( self::DATE_FORMAT ) : null;


### PR DESCRIPTION
As WooCommerce recently updated its DB structure, previous Get order permalink would not work.